### PR TITLE
allow missing '-' and lowercase in validator

### DIFF
--- a/data_transfer/utils/__init__.py
+++ b/data_transfer/utils/__init__.py
@@ -102,7 +102,7 @@ def format_id_patient(patient_id: str) -> Optional[str]:
     Validate and formats patient id s
     NOTE: retains the '-'
     """
-    return __format_id_ideafast(patient_id, 2)
+    return __format_id_ideafast(patient_id, 1)
 
 
 def format_id_device(device_id: str) -> Optional[str]:
@@ -110,7 +110,7 @@ def format_id_device(device_id: str) -> Optional[str]:
     Validate and formats device id s
     NOTE: retains the '-'
     """
-    return __format_id_ideafast(device_id, 4)
+    return __format_id_ideafast(device_id, 3)
 
 
 def __format_id_ideafast(ideafast_id: str, prefix_length: int) -> Optional[str]:
@@ -119,7 +119,9 @@ def __format_id_ideafast(ideafast_id: str, prefix_length: int) -> Optional[str]:
     ideafast/ideafast-idgen. Returns boolean if validate with corrected formatting
     """
     if type(ideafast_id) is str:
-        prefix = ideafast_id[:prefix_length]
+        ideafast_id = ideafast_id.upper()
+        # NOTE: appending a '-' in preperation of a result
+        prefix = f"{ideafast_id[:prefix_length]}-"
         stripped_id = ideafast_id[prefix_length:]
         id_to_check = re.sub(r"[^\w]|_", "", stripped_id)
 

--- a/tests/data_transfer_tests/utils/test_utils.py
+++ b/tests/data_transfer_tests/utils/test_utils.py
@@ -23,13 +23,19 @@ def test_device_valid() -> None:
 def test_device_ideafast_valid_no_prefix() -> None:
     result = __format_id_ideafast("FYCRXH", 0)
 
-    assert result == "FYCRXH"
+    assert result == "-FYCRXH"  # Note the prepended - due to expected prefixes
 
 
 def test_device_ideafast_valid() -> None:
-    result = __format_id_ideafast("ABC-FYCRXH", 4)
+    result = __format_id_ideafast("ABC-FYCRXH", 3)
 
     assert result == "ABC-FYCRXH"
+
+
+def test_weard_prefix_ideafast_valid() -> None:
+    result = __format_id_ideafast("AbCDef129A-FYCRXH", 10)
+
+    assert result == "ABCDEF129A-FYCRXH"
 
 
 def test_device_ideafast_invalid() -> None:
@@ -39,7 +45,7 @@ def test_device_ideafast_invalid() -> None:
 
 
 def test_invalid() -> None:
-    result = format_id_patient("K-NXYP6G")
+    result = format_id_patient("K-NXyP6G")
 
     assert result is None
 
@@ -52,6 +58,12 @@ def test_punctuation() -> None:
 
 def test_tabs_spaces() -> None:
     result = format_id_patient("K-N XYP6\tF ")
+
+    assert result == "K-NXYP6F"
+
+
+def test_lower_case() -> None:
+    result = format_id_patient("knxyp6f")
 
     assert result == "K-NXYP6F"
 


### PR DESCRIPTION
Quick fix to make the validator slightly more flexible, fixing more common human input such as lowercases or missing '-'es


## Testing
Run `poetry run nox -rs tests`