### PR TITLE
Validate Device ID in DRM pipeline

### DIFF
--- a/data_transfer/devices/dreem.py
+++ b/data_transfer/devices/dreem.py
@@ -103,9 +103,16 @@ class Dreem:
                 unknown += 1
                 continue
 
-            device_id = self.__device_id_from_ucam(
+            _device_id = self.__device_id_from_ucam(
                 patient_id, recording.start, recording.end
             ) or inventory.device_id_by_serial(device_serial)
+
+            if not (device_id := utils.format_id_device(_device_id)):
+                log.error(
+                    f"Record NOT created: Error formatting DeviceID ({_device_id}) for\n{recording}\n"
+                )
+                unknown += 1
+                continue
 
             if not patient_id or not device_id:
                 log.error(f"Metadata cannot be determined for {recording}")


### PR DESCRIPTION
Minor oversight in #46, namely that the Patient ID was validated but not the Device ID. I noticed this when reviewing error logs for Rotterdam and also a [seperate bug in dmpy](https://github.com/ideafast/dmpy/issues/6). A modified version of the db record is below to show how it impacted `dmp_folder` and thus why an error was returned from DMP. Notably, the spaces in `device_id`:
 
```json
{
    "device_type" : "DRM",
    "device_id" : "DRM - ABCD",
    "patient_id" : "E-ABCD",
    "dmp_folder" : "ABCD-DRM  ABCD-20210311-20210323",
}
```