### PR TITLE
Refer to logging configuration via config path

### DIFF
--- a/data_transfer/config.py
+++ b/data_transfer/config.py
@@ -23,6 +23,8 @@ class GlobalConfig(BaseSettings):
 
     root_path = Path(__file__).parent.parent
 
+    logger_path = root_path / "logging.ini"
+
     # Stores CSVs for mapping devices to patients.
     # See: local/README.md for more details
     csvs_path = root_path / "local"

--- a/data_transfer/main.py
+++ b/data_transfer/main.py
@@ -5,7 +5,7 @@ from data_transfer.config import config
 from data_transfer.dags import btf, drm, sma
 from data_transfer.utils import DeviceType, StudySite
 
-fileConfig("logging.ini")
+fileConfig(config.logger_path)
 
 if __name__ == "__main__":
     # Create this once upon setup


### PR DESCRIPTION
The location of the logging fle is hardcoded and can therefore be invalid depending on where the python script is run from. Instead, I have moved this path into config and used the root_path as needed.  This resolves a 🐛 in current master. To reproduce:

1. Build docker image locally and run pipeline -- note it fails
2. Switch to this branch and run pipeline -- note success.