### PR TITLE
Nox fix

### DIFF
--- a/data_transfer/dags/btf.py
+++ b/data_transfer/dags/btf.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from data_transfer.db import records_not_downloaded
+from data_transfer.db import records_not_uploaded
 from data_transfer.jobs import byteflies as byteflies_jobs
 from data_transfer.jobs import shared as shared_jobs
 from data_transfer.tasks import byteflies as byteflies_tasks
@@ -26,12 +26,15 @@ def dag(study_site: StudySite) -> None:
     data_period = get_period_by_days(datetime.today(), 2)  # NOTE: two days for testing
     byteflies_jobs.batch_metadata(*data_period, study_site)
 
-    for record in records_not_downloaded(DeviceType.BTF):
-        # Each task should be idempotent. Returned values feeds subsequent task
-        mongoid = byteflies_tasks.task_download_data(record.id)
-        byteflies_tasks.task_preprocess_data(mongoid)
+    results = records_not_uploaded(DeviceType.BTF)
 
-    # Data is finalised and moved to a folder in /uploading/
-    shared_jobs.prepare_data_folders(DeviceType.BTF)
-    # All said folders FOR ALL DEVICES are uploaded once per day
-    shared_jobs.batch_upload_data(DeviceType.BTF)
+    for _patient_device, records in results.items():
+        for record in records:
+            # Each task should be idempotent. Returned values feeds subsequent task
+            mongoid = byteflies_tasks.task_download_data(record.id)
+            byteflies_tasks.task_preprocess_data(mongoid)
+
+        # Data is finalised and moved to a folder in /uploading/
+        shared_jobs.prepare_data_folders(DeviceType.BTF)
+        # All said folders FOR ALL DEVICES are uploaded once per day
+        shared_jobs.batch_upload_data(DeviceType.BTF)

--- a/noxfile.py
+++ b/noxfile.py
@@ -2,14 +2,14 @@ import tempfile
 from typing import Any
 
 import nox
-from nox.sessions import Session
+from nox_poetry import session
 
 package = "session", "data_transfer"
 nox.options.sessions = "black", "lint", "mypy", "tests", "isort"
 locations = "consumer", "data_transfer", "tests", "noxfile.py", "cli.py"
 
 
-def install_with_constraints(session: Session, *args: str, **kwargs: Any) -> None:
+def install_with_constraints(session: nox.Session, *args: str, **kwargs: Any) -> None:
     """A wrapper for session.install use linting and
     test depenencies that are pinned. This ensure
     replicatability amongst developers."""
@@ -26,37 +26,36 @@ def install_with_constraints(session: Session, *args: str, **kwargs: Any) -> Non
         session.install(f"--constraint={requirements.name}", *args, **kwargs)
 
 
-@nox.session(python=["3.8"])
-def black(session: Session) -> None:
+@session(python=["3.8"])
+def black(session: nox.Session) -> None:
     """Automatic format code following black codestyle:
     https://github.com/psf/black
     """
-    args = session.posargs or locations
-    install_with_constraints(session, "black")
-    session.run("black", *args)
+    # args = session.posargs or locations
+    session.install("black")
+    session.run("black", *locations)
 
 
-@nox.session(python=["3.8"])
-def isort(session: Session) -> None:
+@session(python=["3.8"])
+def isort(session: nox.Session) -> None:
     """Automatic order import statements"""
     args = session.posargs or locations
     install_with_constraints(session, "isort")
     session.run("isort", *args)
 
 
-@nox.session(python=["3.8"])
-def mypy(session: Session) -> None:
+@session(python=["3.8"])
+def mypy(session: nox.Session) -> None:
     args = session.posargs or locations
-    install_with_constraints(session, "mypy")
+    session.install("mypy")
     session.run("mypy", *args)
 
 
-@nox.session(python=["3.8"])
-def lint(session: Session) -> None:
+@session(python=["3.8"])
+def lint(session: nox.Session) -> None:
     """Provide lint warnings to help enforce style guide."""
     args = session.posargs or locations
-    install_with_constraints(
-        session,
+    session.install(
         "flake8",
         "flake8-aaa",
         "flake8-bandit",
@@ -66,8 +65,8 @@ def lint(session: Session) -> None:
     session.run("flake8", *args)
 
 
-@nox.session(python=["3.8"])
-def tests(session: Session) -> None:
+@session(python=["3.8"])
+def tests(session: nox.Session) -> None:
     """Setup for automated testing with pytest"""
     session.run("poetry", "run", "pytest", "-vs")
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,6 +1,3 @@
-import tempfile
-from typing import Any
-
 import nox
 from nox_poetry import session
 
@@ -9,38 +6,21 @@ nox.options.sessions = "black", "lint", "mypy", "tests", "isort"
 locations = "consumer", "data_transfer", "tests", "noxfile.py", "cli.py"
 
 
-def install_with_constraints(session: nox.Session, *args: str, **kwargs: Any) -> None:
-    """A wrapper for session.install use linting and
-    test depenencies that are pinned. This ensure
-    replicatability amongst developers."""
-    with tempfile.NamedTemporaryFile() as requirements:
-        session.run(
-            "poetry",
-            "export",
-            "--dev",
-            "--without-hashes",
-            "--format=requirements.txt",
-            f"--output={requirements.name}",
-            external=True,
-        )
-        session.install(f"--constraint={requirements.name}", *args, **kwargs)
-
-
 @session(python=["3.8"])
 def black(session: nox.Session) -> None:
     """Automatic format code following black codestyle:
     https://github.com/psf/black
     """
-    # args = session.posargs or locations
+    args = session.posargs or locations
     session.install("black")
-    session.run("black", *locations)
+    session.run("black", *args)
 
 
 @session(python=["3.8"])
 def isort(session: nox.Session) -> None:
     """Automatic order import statements"""
     args = session.posargs or locations
-    install_with_constraints(session, "isort")
+    session.install("isort")
     session.run("isort", *args)
 
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -458,6 +458,19 @@ virtualenv = ">=14.0.0"
 tox_to_nox = ["jinja2", "tox"]
 
 [[package]]
+name = "nox-poetry"
+version = "0.8.4"
+description = "nox-poetry"
+category = "dev"
+optional = false
+python-versions = ">=3.6.1,<4.0.0"
+
+[package.dependencies]
+nox = ">=2020.8.22"
+packaging = ">=20.9"
+tomlkit = ">=0.7.0,<0.8.0"
+
+[[package]]
 name = "packaging"
 version = "20.9"
 description = "Core utilities for Python packages"
@@ -760,6 +773,14 @@ optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
+name = "tomlkit"
+version = "0.7.0"
+description = "Style preserving TOML library"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
 name = "typed-ast"
 version = "1.4.2"
 description = "a fork of Python 2 and 3 ast modules with type comment support"
@@ -824,7 +845,7 @@ testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "9129485e690d6223ab18894907a0dab98db4c0f7b23e8ba8b02d55c97a65ffea"
+content-hash = "af45292312d7046de80a9862be460ea57b631b2ddd479aa288e92e195cb33b4c"
 
 [metadata.files]
 appdirs = [
@@ -1000,6 +1021,10 @@ nodeenv = [
 nox = [
     {file = "nox-2020.12.31-py3-none-any.whl", hash = "sha256:f179d6990f7a0a9cebad01b9ecea34556518b8d3340dfcafdc1d85f2c1a37ea0"},
     {file = "nox-2020.12.31.tar.gz", hash = "sha256:58a662070767ed4786beb46ce3a789fca6f1e689ed3ac15c73c4d0094e4f9dc4"},
+]
+nox-poetry = [
+    {file = "nox-poetry-0.8.4.tar.gz", hash = "sha256:880536a3f7949c22adc77889165f9222a7c60cc5f81ee8c20a2f22eef4a382b2"},
+    {file = "nox_poetry-0.8.4-py3-none-any.whl", hash = "sha256:d56980487e85fd006f0db5f440781d963be782731158766d2a7551612574417d"},
 ]
 packaging = [
     {file = "packaging-20.9-py2.py3-none-any.whl", hash = "sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a"},
@@ -1247,6 +1272,10 @@ stevedore = [
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
     {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
+]
+tomlkit = [
+    {file = "tomlkit-0.7.0-py2.py3-none-any.whl", hash = "sha256:6babbd33b17d5c9691896b0e68159215a9387ebfa938aa3ac42f4a4beeb2b831"},
+    {file = "tomlkit-0.7.0.tar.gz", hash = "sha256:ac57f29693fab3e309ea789252fcce3061e19110085aa31af5446ca749325618"},
 ]
 typed-ast = [
     {file = "typed_ast-1.4.2-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:7703620125e4fb79b64aa52427ec192822e9f45d37d4b6625ab37ef403e1df70"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ pytest-mock = "^3.5.1"
 requests-mock = "^1.8.0"
 mongomock = "^3.22.1"
 pymongo = "^3.11.3"
+nox-poetry = "^0.8.4"
 
 [tool.poetry.scripts]
 consumer = "cli:consumer"

--- a/tests/data_transfer_tests/byteflies/test_byteflies.py
+++ b/tests/data_transfer_tests/byteflies/test_byteflies.py
@@ -24,12 +24,12 @@ def test_get_list(mock_requests_session: dict) -> None:
 def test_download_file(mock_requests_session: dict, tmpdir: Path) -> None:
     # mock temp storage folder
     lib.config.storage_vol = tmpdir
-    target_folder = "test_download_file"
+    target_folder = tmpdir / "test_download_file"
     target_file_name = "random_id_13"
     target_file = tmpdir / target_folder / f"{target_file_name}.csv"
 
     result = lib.download_file(
-        str(target_folder),
+        target_folder,
         mock_requests_session["session"],
         "studysite_1",
         "random_id_12",
@@ -63,9 +63,9 @@ def test_download_task(
         tasks.Byteflies, "authenticate", return_value=mock_requests_session["session"]
     ):
 
-        for record in db.records_not_downloaded(DeviceType.BTF):
-            devices.Byteflies().download_file(record.id)
-            tasks.task_preprocess_data(record.id)
+        for _key, records in db.records_not_downloaded(DeviceType.BTF).items():
+            devices.Byteflies().download_file(records[0].id)
+            tasks.task_preprocess_data(records[0].id)
 
         result = False
 


### PR DESCRIPTION
`pip` recently dropped support ([see ongoing discourse](https://github.com/pypa/pip/pull/9673)) for setting constraints on url based dependencies. The [`nox-poetry`](https://github.com/cjolowicz/nox-poetry/blob/main/src/nox_poetry/sessions.py) resolved this in their package recently (I believe by ignoring url based dependencies in the requirements.txt file export). This PR implements the `nox-poetry`. Nox-poetry replaces the logic to install with contraints in `nox`. 


## Testing
- Pull `nox_fix` branch
- run `poetry install`
- run `poetry shell`
- run `poetry run nox -r`
Everything should pass expect two tests