### PR TITLE
Byteflies update, closes #27

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,10 @@ When developing the consumer API run:
 
     poetry run consumer
 
-When developing the data transfer jobs run where `DEVICE_TYPE` is the type of device (e.g., DRM, BTF, etc.) and `study_site` is one of the core study sites. View the [DAGs in data_transfer](./data_transfer/dags/) for more information:
+When developing the data transfer jobs run where `DEVICE_TYPE` is the type of device (e.g., DRM, BTF, etc.) and `study_site` is one of the core study sites. Note, for BTF you can add timespan parameters. View the [DAGs in data_transfer](./data_transfer/dags/) for more information:
 
     python data_transfer/main.py $DEVICE_TYPE $STUDY_SITE
+    python data_transfer/main.py BTF $STUDY_SITE $REFERENCE_DAY $DAYS_TIMESPAN
 
 ### Running Tests, Type Checking, Linting and Code Formatting
 

--- a/data_transfer/config.py
+++ b/data_transfer/config.py
@@ -33,7 +33,7 @@ class GlobalConfig(BaseSettings):
     storage_vol: Path = data_path / "input"
     upload_folder: Path = data_path / "uploading"
 
-    byteflies_devices = root_path / "byteflies_devices.csv"
+    byteflies_devices = csvs_path / "byteflies_devices.csv"
 
     dreem_users: Path = csvs_path / "dreem_users.csv"
     dreem_devices: Path = csvs_path / "dreem_devices.csv"

--- a/data_transfer/config.py
+++ b/data_transfer/config.py
@@ -34,6 +34,7 @@ class GlobalConfig(BaseSettings):
     upload_folder: Path = data_path / "uploading"
 
     byteflies_devices = csvs_path / "byteflies_devices.csv"
+    byteflies_historical_start = "2020-07-01"
 
     dreem_users: Path = csvs_path / "dreem_users.csv"
     dreem_devices: Path = csvs_path / "dreem_devices.csv"

--- a/data_transfer/config.py
+++ b/data_transfer/config.py
@@ -33,7 +33,6 @@ class GlobalConfig(BaseSettings):
     storage_vol: Path = data_path / "input"
     upload_folder: Path = data_path / "uploading"
 
-    byteflies_devices = csvs_path / "byteflies_devices.csv"
     byteflies_historical_start = "2020-07-01"
 
     dreem_users: Path = csvs_path / "dreem_users.csv"

--- a/data_transfer/dags/btf.py
+++ b/data_transfer/dags/btf.py
@@ -65,5 +65,3 @@ def dag(
             shared_jobs.batch_upload_data(DeviceType.BTF)
         else:
             log.error(f"Some records for {patient_device} were not downloaded.")
-
-        break

--- a/data_transfer/dags/btf.py
+++ b/data_transfer/dags/btf.py
@@ -68,13 +68,15 @@ def dag(
             log.error(f"Some records for {patient_device} were not downloaded.")
 
 
-def historical_dag(study_site: StudySite, delta: int) -> None:
+def historical_dag(
+    study_site: StudySite, _days: Union[int, str] = -1, delta: Union[int, str] = 0
+) -> None:
     """Loops through set periods to retreive all historical data"""
     days_to_cover = (
         datetime.today() - datetime.fromisoformat(config.byteflies_historical_start)
     ).days
     # jump straight to delta reference and skip days in between
-    tracker = delta
+    tracker = int(delta)
     while tracker < days_to_cover:
         dag(study_site, 50, tracker)
         # ensure 1 day overlap for sanity

--- a/data_transfer/dags/btf.py
+++ b/data_transfer/dags/btf.py
@@ -1,13 +1,17 @@
+import logging
 from datetime import datetime
 
-from data_transfer.db import records_not_uploaded
+from data_transfer.db import all_records_downloaded, records_not_uploaded
+from data_transfer.devices.byteflies import Byteflies
 from data_transfer.jobs import byteflies as byteflies_jobs
 from data_transfer.jobs import shared as shared_jobs
 from data_transfer.tasks import byteflies as byteflies_tasks
 from data_transfer.utils import DeviceType, StudySite, get_period_by_days
 
+log = logging.getLogger(__name__)
 
-def dag(study_site: StudySite) -> None:
+
+def dag(study_site: StudySite, timespan: int, now: int = -1) -> None:
     """
     Directed acyclic graph (DAG) representing dreem data pipeline:
 
@@ -17,24 +21,40 @@ def dag(study_site: StudySite) -> None:
             ->task_prepare_data
         ->batch_upload_data
 
+    Parameters
+    ----------
+    study_site : StudySite
+    timespan : int
+        The amount of days in the past to query data for. This should
+        correspond with the pipeline recurrance + margin to ensure overlap
+    now : int, optional
+        The unix time to reference timespan to, defaults to today for the pipeline.
+        Allows traversing and stepping through the past for historical data
+
+
     NOTE/TODO: this method simulates the pipeline.
     """
 
-    # TODO: ensure that we get the End of Day as intended based on automation schedule
-    # TODO: should we ensure overlap with previous run? How often do we run this DAG?
-    # TODO: perhaps pull this one abstraction higher (into the init of this DAG?)
-    data_period = get_period_by_days(datetime.today(), 2)  # NOTE: two days for testing
+    byteflies = Byteflies()
+
+    reference: datetime = datetime.today() if now == -1 else datetime.fromtimestamp(now)
+    data_period = get_period_by_days(reference, timespan)
     byteflies_jobs.batch_metadata(*data_period, study_site)
 
     results = records_not_uploaded(DeviceType.BTF)
 
-    for _patient_device, records in results.items():
+    # NOTE: group records by patients per device to process small batches.
+    for patient_device, records in results.items():
         for record in records:
             # Each task should be idempotent. Returned values feeds subsequent task
-            mongoid = byteflies_tasks.task_download_data(record.id)
+            mongoid = byteflies_tasks.task_download_data(byteflies, record.id)
             byteflies_tasks.task_preprocess_data(mongoid)
 
-        # Data is finalised and moved to a folder in /uploading/
-        shared_jobs.prepare_data_folders(DeviceType.BTF)
-        # All said folders FOR ALL DEVICES are uploaded once per day
-        shared_jobs.batch_upload_data(DeviceType.BTF)
+        # Only upload when all records are ready
+        if all_records_downloaded(records):
+            log.debug(f"All records for {patient_device} DOWNLOADED -> PREPARING ...")
+            shared_jobs.prepare_data_folders(DeviceType.BTF)
+            log.debug(f"All records for {patient_device} PREPARED   -> UPLOADING ...")
+            shared_jobs.batch_upload_data(DeviceType.BTF)
+        else:
+            log.error(f"Some records for {patient_device} were not downloaded.")

--- a/data_transfer/dags/btf.py
+++ b/data_transfer/dags/btf.py
@@ -68,16 +68,13 @@ def dag(
             log.error(f"Some records for {patient_device} were not downloaded.")
 
 
-def historical_dag(
-    study_site: StudySite, _days: Union[int, str] = -1, delta: Union[int, str] = 0
-) -> None:
+def historical_dag(study_site: StudySite, _days: int = -1, delta: int = 0) -> None:
     """Loops through set periods to retreive all historical data"""
     days_to_cover = (
         datetime.today() - datetime.fromisoformat(config.byteflies_historical_start)
     ).days
     # jump straight to delta reference and skip days in between
-    tracker = int(delta)
-    while tracker < days_to_cover:
-        dag(study_site, 50, tracker)
+    while delta < days_to_cover:
+        dag(study_site, 50, delta)
         # ensure 1 day overlap for sanity
-        tracker += 49
+        delta += 49

--- a/data_transfer/dags/btf.py
+++ b/data_transfer/dags/btf.py
@@ -1,6 +1,5 @@
 import logging
 from datetime import datetime
-from typing import Union
 
 from data_transfer.config import config
 from data_transfer.db import all_records_downloaded, records_not_uploaded
@@ -13,9 +12,7 @@ from data_transfer.utils import DeviceType, StudySite, get_period_by_days
 log = logging.getLogger(__name__)
 
 
-def dag(
-    study_site: StudySite, days: Union[int, str] = 50, delta: Union[int, str] = 0
-) -> None:
+def dag(study_site: StudySite, days: int = 50, delta: int = 0) -> None:
     """
     Directed acyclic graph (DAG) representing dreem data pipeline:
 
@@ -40,7 +37,7 @@ def dag(
     """
     byteflies = Byteflies(study_site)
 
-    data_period = get_period_by_days(int(delta), int(days))
+    data_period = get_period_by_days(delta, days)
 
     log.debug(
         f"Dowloading records from {datetime.fromtimestamp(int(data_period[0]))}"

--- a/data_transfer/dags/btf.py
+++ b/data_transfer/dags/btf.py
@@ -35,11 +35,12 @@ def dag(study_site: StudySite, timespan: int, now: int = -1) -> None:
     NOTE/TODO: this method simulates the pipeline.
     """
 
-    byteflies = Byteflies()
+    byteflies = Byteflies(study_site)
 
     reference: datetime = datetime.today() if now == -1 else datetime.fromtimestamp(now)
     data_period = get_period_by_days(reference, timespan)
-    byteflies_jobs.batch_metadata(*data_period, study_site)
+
+    byteflies_jobs.batch_metadata(byteflies, *data_period)
 
     results = records_not_uploaded(DeviceType.BTF)
 

--- a/data_transfer/devices/byteflies.py
+++ b/data_transfer/devices/byteflies.py
@@ -103,8 +103,7 @@ class Byteflies:
             # Pulls out the most relevant metadata for this recording
             recording = self.recording_metadata(item)
 
-            # NOTE: lookup in .csv export from inventory TODO: translate to inventory api
-            if not (_device_id := byteflies_api.serial_by_device(recording.dot_id)):
+            if not (_device_id := inventory.device_id_by_serial(recording.dot_id)):
                 log.debug(f"Record NOT created for unknown device\n   {recording}")
                 unknown += 1
                 continue  # Skip record

--- a/data_transfer/devices/byteflies.py
+++ b/data_transfer/devices/byteflies.py
@@ -1,4 +1,5 @@
 import logging
+import time
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
@@ -259,8 +260,8 @@ class Byteflies:
         Determine PatientID by wear period of device in UCAM.
         """
         record = ucam.record_by_wear_period(device_id, start, end)
-        if record:
-            print("found in UCAM")
+        # TODO: inventory has small rate limit.
+        time.sleep(4)
         return record.patient_id if record else None
 
     def __patient_id_from_inventory(
@@ -270,6 +271,6 @@ class Byteflies:
         Determine PatientID by wear period in inventory.
         """
         record = inventory.record_by_device_id(device_id, start, end)
-        if record:
-            print("found in Inventory")
+        # TODO: inventory has small rate limit.
+        time.sleep(4)
         return record.get("patient_id", None) if record else None

--- a/data_transfer/devices/byteflies.py
+++ b/data_transfer/devices/byteflies.py
@@ -73,7 +73,7 @@ class Byteflies:
         log.info("Authentication successful")
         return session
 
-    def download_metadata(self, from_date: str, to_date: str) -> None:
+    def download_metadata(self, from_date: int, to_date: int) -> None:
         """
         Before downloading raw data we need to know which files to download.
         Byteflies offers an API which we can query for a given time period
@@ -193,7 +193,7 @@ class Byteflies:
             log.debug("Data file already downloaded. Skipping.")
             return
 
-        is_downloaded_success = byteflies_api.download_file(
+        filename = byteflies_api.download_file(
             self.session,
             record.download_folder(),
             record.meta["studysite_id"],
@@ -202,11 +202,11 @@ class Byteflies:
             record.meta["algorithm_id"],
         )
 
-        # filename if succes, False is not
-        if is_downloaded_success:
+        # filename if succes, None if not
+        if filename:
             # Useful metadata for performing pre-processing.
             downloaded_file = Path(
-                record.download_folder() / f"{is_downloaded_success}{self.file_type}"
+                record.download_folder() / f"{filename}{self.file_type}"
             )
             record.meta["filesize"] = downloaded_file.stat().st_size
 

--- a/data_transfer/jobs/byteflies.py
+++ b/data_transfer/jobs/byteflies.py
@@ -1,10 +1,8 @@
 from data_transfer.devices.byteflies import Byteflies
-from data_transfer.utils import StudySite
 
 
-def batch_metadata(from_date: str, to_date: str, study_site: StudySite) -> None:
+def batch_metadata(byteflies: Byteflies, from_date: str, to_date: str) -> None:
     """
     This method stores the records we have not yet processed.
     """
-    byteflies = Byteflies()
-    byteflies.download_metadata(from_date, to_date, study_site)
+    byteflies.download_metadata(from_date, to_date)

--- a/data_transfer/jobs/byteflies.py
+++ b/data_transfer/jobs/byteflies.py
@@ -1,7 +1,7 @@
 from data_transfer.devices.byteflies import Byteflies
 
 
-def batch_metadata(byteflies: Byteflies, from_date: str, to_date: str) -> None:
+def batch_metadata(byteflies: Byteflies, from_date: int, to_date: int) -> None:
     """
     This method stores the records we have not yet processed.
     """

--- a/data_transfer/lib/byteflies.py
+++ b/data_transfer/lib/byteflies.py
@@ -3,7 +3,7 @@ import logging
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, List, Optional, Union
+from typing import Any, List, Optional
 
 import requests
 
@@ -51,7 +51,7 @@ def get_session(token: str) -> requests.Session:
 
 
 def get_list(
-    session: requests.Session, studysite_id: str, from_date: str, to_date: str
+    session: requests.Session, studysite_id: str, from_date: int, to_date: int
 ) -> List[dict]:
     """
     GET a list of records (metadata) across study sites, or 'groups' in ByteFlies API
@@ -106,7 +106,7 @@ def download_file(
     recording_id: str,
     signal_id: str,
     algorithm_id: str = "",
-) -> Union[bool, str]:
+) -> Optional[str]:
     """
     Download all files associated with one ByteFlies recording.
     """
@@ -128,10 +128,10 @@ def download_file(
 
         if __download_file(download_folder, url, filename):
             return filename
-        return False
+        return None
     except requests.HTTPError:
         log.error(f"GET Exception to {url} ", exc_info=True)
-        return False
+        return None
 
 
 def serial_by_device(uuid: str) -> Optional[str]:
@@ -186,7 +186,7 @@ def __get_groups(session: requests.Session) -> List[str]:
 
 
 def __get_recordings_by_group(
-    session: requests.Session, studysite_id: str, begin_date: str, end_date: str
+    session: requests.Session, studysite_id: str, begin_date: int, end_date: int
 ) -> Any:
     """Returns the list of Recordings associated to a Group"""
     return __get_response(

--- a/data_transfer/lib/byteflies.py
+++ b/data_transfer/lib/byteflies.py
@@ -137,14 +137,6 @@ def download_file(
         return None
 
 
-def serial_by_device(uuid: str) -> Optional[str]:
-    """
-    Lookup Device ID by ByteFlies dot.id
-    """
-    serial = __key_by_value(config.byteflies_devices, uuid)
-    return serial
-
-
 def __key_by_value(filename: Path, needle: str) -> Optional[str]:
     """
     Helper method to find key in CSV by value (needle)

--- a/data_transfer/lib/byteflies.py
+++ b/data_transfer/lib/byteflies.py
@@ -223,7 +223,7 @@ def __download_file(download_folder: Path, url: str, filename: str) -> bool:
         path = download_folder / f"{filename}.csv"
 
         with requests.get(url, stream=True) as response:
-            log.debug(response.headers)
+            log.debug(f"Headers from {url} was:\n    {response.headers}")
 
             response.raise_for_status()
 

--- a/data_transfer/lib/byteflies.py
+++ b/data_transfer/lib/byteflies.py
@@ -88,6 +88,9 @@ def get_list(
             session, studysite_id, recording["id"]
         )
 
+        for signal in recording_details["signals"]:
+            del signal["rawData"]
+
         template = __metadata_copy(json.dumps(recording_details))
 
         for signal in recording_details["signals"]:

--- a/data_transfer/lib/byteflies.py
+++ b/data_transfer/lib/byteflies.py
@@ -8,7 +8,7 @@ from typing import Any, List, Optional
 import requests
 
 from data_transfer.config import config
-from data_transfer.utils import DeviceType, read_csv_from_cache, uid_to_hash
+from data_transfer.utils import DeviceType, uid_to_hash
 
 log = logging.getLogger(__name__)
 
@@ -135,17 +135,6 @@ def download_file(
     except requests.HTTPError:
         log.error(f"GET Exception to {url} ", exc_info=True)
         return None
-
-
-def __key_by_value(filename: Path, needle: str) -> Optional[str]:
-    """
-    Helper method to find key in CSV by value (needle)
-    """
-    data = read_csv_from_cache(filename)
-    for item in data:
-        if needle == item["Serial"]:
-            return str(item["Asset Tag"])
-    return None
 
 
 def __get_response(session: requests.Session, url: str) -> Any:

--- a/data_transfer/main.py
+++ b/data_transfer/main.py
@@ -22,17 +22,18 @@ if __name__ == "__main__":
     config.storage_vol.mkdir(exist_ok=True)
     config.upload_folder.mkdir(exist_ok=True)
 
-    device = DeviceType[sys.argv[1]] or None
-    study_site = StudySite[sys.argv[2].capitalize()] or None
+    device = DeviceType[sys.argv[1]]
+    study_site = StudySite[sys.argv[2].capitalize()]
 
     if device == DeviceType.DRM:
         drm.dag(study_site)
     if device == DeviceType.SMA:
         sma.dag()
     if device == DeviceType.BTF:
-        # if 'days' == -1, trigger full history
-        if len(sys.argv) >= 4 and int(sys.argv[3]) == -1:
-            btf.historical_dag(study_site, *sys.argv[3:])
+        btf_params = [int(x) for x in sys.argv[3:]]
+
+        if len(btf_params) and btf_params[0] == -1:
+            btf.historical_dag(study_site, *btf_params)
         else:
             # passes timespan and reference if present
-            btf.dag(study_site, *sys.argv[3:])
+            btf.dag(study_site, *btf_params)

--- a/data_transfer/main.py
+++ b/data_transfer/main.py
@@ -16,11 +16,10 @@ if __name__ == "__main__":
 
     device = DeviceType[sys.argv[1]] or None
     study_site = StudySite[sys.argv[2].capitalize()] or None
-    timespan = int(sys.argv[3]) if len(sys.argv) >= 4 else 2
 
     if device == DeviceType.DRM:
         drm.dag(study_site)
     if device == DeviceType.SMA:
         sma.dag()
     if device == DeviceType.BTF:
-        btf.dag(study_site, timespan)
+        btf.dag(study_site, *sys.argv[3:])

--- a/data_transfer/main.py
+++ b/data_transfer/main.py
@@ -16,7 +16,7 @@ if __name__ == "__main__":
 
     device = DeviceType[sys.argv[1]] or None
     study_site = StudySite[sys.argv[2].capitalize()] or None
-    timespan = int(sys.argv[3]) or 2  # default 2 days for testing
+    timespan = int(sys.argv[3]) if len(sys.argv) >= 4 else 2
 
     if device == DeviceType.DRM:
         drm.dag(study_site)

--- a/data_transfer/main.py
+++ b/data_transfer/main.py
@@ -16,10 +16,11 @@ if __name__ == "__main__":
 
     device = DeviceType[sys.argv[1]] or None
     study_site = StudySite[sys.argv[2].capitalize()] or None
+    timespan = int(sys.argv[3]) or 2  # default 2 days for testing
 
     if device == DeviceType.DRM:
         drm.dag(study_site)
     if device == DeviceType.SMA:
         sma.dag()
     if device == DeviceType.BTF:
-        btf.dag(study_site)
+        btf.dag(study_site, timespan)

--- a/data_transfer/main.py
+++ b/data_transfer/main.py
@@ -31,8 +31,8 @@ if __name__ == "__main__":
         sma.dag()
     if device == DeviceType.BTF:
         # if 'days' == -1, trigger full history
-        if len(sys.argv) >= 5 and int(sys.argv[3]) == -1:
-            btf.historical_dag(study_site, int(sys.argv[4]))
+        if len(sys.argv) >= 4 and int(sys.argv[3]) == -1:
+            btf.historical_dag(study_site, *sys.argv[3:])
         else:
             # passes timespan and reference if present
             btf.dag(study_site, *sys.argv[3:])

--- a/data_transfer/main.py
+++ b/data_transfer/main.py
@@ -1,5 +1,4 @@
 import sys
-from datetime import datetime
 from logging.config import fileConfig
 
 from data_transfer.config import config
@@ -9,19 +8,14 @@ from data_transfer.utils import DeviceType, StudySite
 fileConfig(config.logger_path)
 
 
-def historical_btf(study_site: StudySite) -> None:
-    """Loops through set periods to retreive all historical data"""
-    days_to_cover = (
-        datetime.today() - datetime.fromisoformat(config.byteflies_historical_start)
-    ).days
-    tracker = 0
-    while tracker < days_to_cover:
-        btf.dag(study_site, 50, tracker)
-        # ensure 1 day overlap for sanity
-        tracker += 49
-
-
 if __name__ == "__main__":
+    """
+    Usages:
+    >   python data_transfer/main.py [DeviceType] [StudySite]
+    For BTF, additional args to query a period of data:
+    >   python data_transfer/main.py [DeviceType] [StudySite] [days] [reference_day]
+    >   [days] == -1 will trigger a historical query to the beginning of the IDEAFAST FS
+    """
     # Create this once upon setup
     config.csvs_path.mkdir(exist_ok=True)
     config.data_path.mkdir(exist_ok=True)
@@ -37,8 +31,8 @@ if __name__ == "__main__":
         sma.dag()
     if device == DeviceType.BTF:
         # if 'days' == -1, trigger full history
-        if len(sys.argv) >= 4 and int(sys.argv[3]) == -1:
-            historical_btf(study_site)
+        if len(sys.argv) >= 5 and int(sys.argv[3]) == -1:
+            btf.historical_dag(study_site, int(sys.argv[4]))
         else:
             # passes timespan and reference if present
             btf.dag(study_site, *sys.argv[3:])

--- a/data_transfer/tasks/byteflies.py
+++ b/data_transfer/tasks/byteflies.py
@@ -2,11 +2,11 @@ from data_transfer.db import read_record, update_record
 from data_transfer.devices.byteflies import Byteflies
 
 
-def task_download_data(mongoid: str) -> str:
+def task_download_data(byteflies: Byteflies, mongoid: str) -> str:
     """
     Download a datafile for a byteflies device.
     """
-    Byteflies().download_file(mongoid)
+    byteflies.download_file(mongoid)
     return mongoid
 
 

--- a/data_transfer/tasks/byteflies.py
+++ b/data_transfer/tasks/byteflies.py
@@ -15,6 +15,7 @@ def task_preprocess_data(mongoid: str) -> str:
     Preprocessing tasks on byteflies data.
     """
     record = read_record(mongoid)
-    record.is_processed = True
-    update_record(record)
+    if not record.is_processed:
+        record.is_processed = True
+        update_record(record)
     return mongoid

--- a/data_transfer/utils/__init__.py
+++ b/data_transfer/utils/__init__.py
@@ -47,10 +47,16 @@ def format_weartime_from_timestamp(period: int) -> datetime:
     return datetime.fromtimestamp(period)
 
 
-def get_period_by_days(start: datetime, days: int) -> Tuple[str, str]:
+def get_period_by_days(start: int, days: int) -> Tuple[str, str]:
     """return two timestamps based on a startdate and duration"""
-    end_date = start.replace(hour=23, minute=59)
-    from_date = end_date - timedelta(days=days)
+    reference = datetime.today() - timedelta(days=start)
+
+    # ensure end at night, but start in the morning to capture everything _those days_
+    end_date = reference.replace(hour=23, minute=59, second=59, microsecond=999999)
+    from_date = end_date - timedelta(
+        days=days, hours=23, minutes=59, seconds=59, microseconds=999999
+    )
+
     begin = str(int(from_date.timestamp()))
     end = str(int(end_date.timestamp()))
     return (begin, end)

--- a/data_transfer/utils/__init__.py
+++ b/data_transfer/utils/__init__.py
@@ -47,7 +47,7 @@ def format_weartime_from_timestamp(period: int) -> datetime:
     return datetime.fromtimestamp(period)
 
 
-def get_period_by_days(start: int, days: int) -> Tuple[str, str]:
+def get_period_by_days(start: int, days: int) -> Tuple[int, int]:
     """return two timestamps based on a startdate and duration"""
     reference = datetime.today() - timedelta(days=start)
 
@@ -57,8 +57,8 @@ def get_period_by_days(start: int, days: int) -> Tuple[str, str]:
         days=days, hours=23, minutes=59, seconds=59, microseconds=999999
     )
 
-    begin = str(int(from_date.timestamp()))
-    end = str(int(end_date.timestamp()))
+    begin = int(from_date.timestamp())
+    end = int(end_date.timestamp())
     return (begin, end)
 
 

--- a/local/README.md
+++ b/local/README.md
@@ -3,6 +3,5 @@
 Ensure that you have the required `.csv` files in the `root/local` folder before running the pipeline. This currently includes
 
 - `ucam_db.csv`: a placeholder mapping between device_ids, patient_ids and wear_times until the UCAM API is set up,
-- `byteflies_devices.csv`: a placeholder export from the inventory, mapping BTF device serials with device_ids.
 - `dreem_users.csv`: a mapping between DRM user emails and their DRM uid.
 - `dreem_devices.csv`: a mapping between headband serials and DRM uid.

--- a/tests/data_transfer_tests/byteflies/test_byteflies.py
+++ b/tests/data_transfer_tests/byteflies/test_byteflies.py
@@ -11,9 +11,7 @@ from data_transfer.lib import byteflies as lib
 @patch.object(lib.time, "sleep")
 def test_get_list(mock_time_sleep: Mock, mock_requests_session: dict) -> None:
 
-    result = lib.get_list(
-        mock_requests_session["session"], "studysite_1", "begindate", "enddate"
-    )
+    result = lib.get_list(mock_requests_session["session"], "studysite_1", 0, 1)
 
     # NOTE: Can't replicate, but sleep_call_count failed on me once (was 26853)
     assert mock_time_sleep.call_count == 5

--- a/tests/data_transfer_tests/byteflies/test_byteflies.py
+++ b/tests/data_transfer_tests/byteflies/test_byteflies.py
@@ -1,45 +1,45 @@
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from pymongo.collection import Collection
 
 from data_transfer.db import main as db
-from data_transfer.devices import byteflies as devices
 from data_transfer.lib import byteflies as lib
-from data_transfer.tasks import byteflies as tasks
-from data_transfer.utils import DeviceType
 
 
-def test_get_list(mock_requests_session: dict) -> None:
+@patch.object(lib.time, "sleep")
+def test_get_list(mock_time_sleep: Mock, mock_requests_session: dict) -> None:
 
     result = lib.get_list(
         mock_requests_session["session"], "studysite_1", "begindate", "enddate"
     )
 
+    assert mock_time_sleep.call_count == 5
     assert mock_requests_session["get_all"].call_count == 1
     assert mock_requests_session["get_one"].call_count == 4
     assert len(result) == 40
 
 
 def test_download_file(mock_requests_session: dict, tmpdir: Path) -> None:
-    # mock temp storage folder
-    lib.config.storage_vol = tmpdir
-    target_folder = tmpdir / "test_download_file"
-    target_file_name = "random_id_13"
-    target_file = tmpdir / target_folder / f"{target_file_name}.csv"
 
-    result = lib.download_file(
-        target_folder,
-        mock_requests_session["session"],
-        "studysite_1",
-        "random_id_12",
-        target_file_name,
-        "",
-    )
+    # patch storage_folder, and requests, as _download_file() does not use the byteflies session
+    with patch.object(lib, "requests", mock_requests_session["session"]), patch.object(
+        lib.config, "storage_vol", tmpdir
+    ):
 
-    assert mock_requests_session["get_file"].call_count == 1
-    assert Path(target_file).is_file()
+        result = lib.download_file(
+            mock_requests_session["session"],
+            tmpdir,
+            "studysite_1",
+            "random_id_12",
+            "random_id_13",
+            "",
+        )
+
     assert result
+    assert mock_requests_session["get_one"].call_count == 1
+    assert mock_requests_session["get_file"].call_count == 1
+    assert Path(tmpdir / "random_id_13.csv").is_file()
 
 
 def test_populated_db(populated_db: Collection) -> None:
@@ -48,26 +48,3 @@ def test_populated_db(populated_db: Collection) -> None:
         result = len(db.all_hashes())
 
         assert result == 40
-
-
-def test_download_task(
-    populated_db: Collection, mock_requests_session: dict, tmpdir: Path
-) -> None:
-    # TODO: fix this test
-    # TODO: overrule 1 second sleep.time in api calls
-    # patching
-    db._db = populated_db
-    devices.byteflies_api.config.storage_vol = tmpdir
-
-    with patch.object(db, "_db", populated_db), patch.object(
-        tasks.Byteflies, "authenticate", return_value=mock_requests_session["session"]
-    ):
-
-        for _key, records in db.records_not_downloaded(DeviceType.BTF).items():
-            devices.Byteflies().download_file(records[0].id)
-            tasks.task_preprocess_data(records[0].id)
-
-        result = False
-
-        # to debug, raise to read stdout
-        assert result

--- a/tests/data_transfer_tests/byteflies/test_byteflies.py
+++ b/tests/data_transfer_tests/byteflies/test_byteflies.py
@@ -62,12 +62,13 @@ def test_historical_dag_coverage(
 ) -> None:
     dags.historical_dag(mock_city)
     timespans = [call.args[1:3] for call in mock_batch_metadata.call_args_list]
-    comparison = []
-    for num, timespan in enumerate(timespans):
-        if num < len(timespans) - 1:
-            # the 'from' should be before the next 'end' to ensure overlap
-            comparison.append(timespan[0] < timespans[num + 1][1])
 
-    result = all(comparison)
+    result = all(
+        [
+            ts[0] < timespans[num + 1][1]
+            for num, ts in enumerate(timespans)
+            if num < len(timespans) - 1
+        ]
+    )
 
     assert result


### PR DESCRIPTION
These changes ensure that the ByteFlies branch follows a similar flow to the Dreem branch, including folder structure, batch-processing by patient+device_id as well as logging. 

Partially responds to #28 (at least for testing) 

## Test
- pull down branch
- run `poetry install`
- run `poetry shell`
- run `poetry run nox -rs` for all tests
- run `poetry run consumer` to run the inventory for the overall pipeline
- ensure that you have the mongo DB running
- ensure your `.envs` are correctly set - including `ACCESS_AUTHENTICATED_ENDPOINTS=True` in `.consumer.env`
- run `python data_transfer/main.py BTF Kiel 0 1` to run the BTF pipeline for today (`0`) and yesterday (`1`)

For testing the historical data pipeline, I suggest to add `return` [after logging the data period here](https://github.com/ideafast/middleware-services/blob/352459b483275c166011d71ff435bf17a1aeb2bb/data_transfer/dags/btf.py#L49), and run:
- `python data_transfer/main.py BTF Kiel -1`