### PR TITLE
Inventory fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,6 @@ ucam_db*.csv
 dmypy.json
 *.log
 *.json
+!/tests/*/*/data/*.json
 *.csv
 *.h5

--- a/data_transfer/utils/__init__.py
+++ b/data_transfer/utils/__init__.py
@@ -94,7 +94,7 @@ def normalise_day(_datetime: datetime) -> datetime:
     """
     Replaces day time with zero for comparison by day.
     """
-    return _datetime.replace(hour=0, minute=0, second=0)
+    return _datetime.replace(hour=0, minute=0, second=0, microsecond=0)
 
 
 def format_id_patient(patient_id: str) -> Optional[str]:

--- a/tests/data_transfer_tests/services/conftest.py
+++ b/tests/data_transfer_tests/services/conftest.py
@@ -1,8 +1,14 @@
 from pathlib import Path
 
 import pytest
+import requests
+import requests_mock
 
+from data_transfer import utils
+from data_transfer.config import config
 from data_transfer.services import ucam
+
+folder = Path(__file__).parent
 
 
 @pytest.fixture(scope="function")
@@ -10,5 +16,26 @@ def mock_data() -> None:
     """
     Overrides configuration to use mock data
     """
-    folder = Path(__file__).parent
     ucam.config.ucam_data = Path(f"{folder}/data/mock_ucam_db.csv")
+
+
+@pytest.fixture
+def mock_inventory_requests() -> dict:
+    inventory_history_response = utils.read_json(
+        Path(f"{folder}/data/mock_inventory_history.json")
+    )
+    session = requests.Session()
+    adapter = requests_mock.Adapter()
+
+    config.inventory_api = f"mock://{config.inventory_api[len('http://'):]}"
+
+    # mocks _device_history
+    get_history = adapter.register_uri(
+        "GET",
+        f"{config.inventory_api}device/history/BTF-123456",
+        json=inventory_history_response,
+        status_code=200,
+    )
+
+    session.mount("mock://", adapter)
+    return {"session": session, "get_history": get_history}

--- a/tests/data_transfer_tests/services/data/mock_inventory_history.json
+++ b/tests/data_transfer_tests/services/data/mock_inventory_history.json
@@ -1,0 +1,32 @@
+{
+    "data": {
+        "A-ABCDEF": {
+            "patient_id": "A-ABCDEF",
+            "device_id": "BTF-123456",
+            "checkout": "2021-03-18 19:38:49",
+            "checkin": null
+        },
+        "A-HIJKLM": {
+            "patient_id": "A-HIJKLM",
+            "device_id": "BTF-123456",
+            "checkout": "2021-01-26 11:45:54",
+            "checkin": "2021-02-03 10:58:11"
+        },
+        "A-NOPQRS": {
+            "patient_id": "A-NOPQRS",
+            "device_id": "BTF-123456",
+            "checkout": "2020-11-10 11:24:03",
+            "checkin": "2020-11-10 11:24:04"
+        },
+        "A-TUVWXY": {
+            "patient_id": "A-TUVWXY",
+            "device_id": "BTF-123456",
+            "checkout": "2020-10-09 10:46:02",
+            "checkin": "2020-11-02 10:08:59"
+        }
+    },
+    "meta": {
+        "success": true,
+        "errors": null
+    }
+}

--- a/tests/data_transfer_tests/services/test_inventory.py
+++ b/tests/data_transfer_tests/services/test_inventory.py
@@ -1,0 +1,38 @@
+from datetime import datetime
+from unittest.mock import patch
+
+from data_transfer import utils
+from data_transfer.services import inventory
+
+
+def test_date_within(mock_inventory_requests: dict) -> None:
+
+    with patch.object(inventory, "requests", mock_inventory_requests["session"]):
+        start_wear = utils.format_weartime("2021-03-22 12:11:55", "inventory")
+        end_wear = utils.format_weartime("2021-03-22 22:11:55", "inventory")
+
+        result = inventory.record_by_device_id("BTF-123456", start_wear, end_wear)[
+            "patient_id"
+        ]
+
+        assert result == "A-ABCDEF"
+
+
+def test_date_outside(mock_inventory_requests: dict) -> None:
+
+    with patch.object(inventory, "requests", mock_inventory_requests["session"]):
+        start_wear = utils.format_weartime("2021-03-17 12:11:55", "inventory")
+        end_wear = utils.format_weartime("2021-03-17 22:11:55", "inventory")
+
+        result = inventory.record_by_device_id("BTF-123456", start_wear, end_wear)
+
+        assert result is None
+
+
+def test_normalise_day() -> None:
+    one = utils.normalise_day(datetime(2021, 3, 26, 0, 0, 0, 647241))
+    two = utils.normalise_day(datetime(2021, 3, 26, 0, 0, 0, 565704))
+
+    result = one == two
+
+    assert result


### PR DESCRIPTION
Fixed the inventory comparison issue due to the the missing microseconds in `normalise_day`. Also added three test (as a starter) to ensure the inventory code  behaves as expected - though the inventory itself is thereby not tested (yet).

Note that this branches off master, hence a test or two in the ByteFlies branch will not pass.

## Test
- run `poetry run nox -rs tests`