### PR TITLE
remove logs for URL requests; overloading the log

### DIFF
--- a/data_transfer/lib/byteflies.py
+++ b/data_transfer/lib/byteflies.py
@@ -147,6 +147,7 @@ def __get_response(session: requests.Session, url: str) -> Any:
     time.sleep(1)
     try:
         response = session.get(url)
+        log.info(f"Response from {url} was:\n    {response.headers}")
         response.raise_for_status()
 
         result: dict = response.json()

--- a/data_transfer/lib/byteflies.py
+++ b/data_transfer/lib/byteflies.py
@@ -151,8 +151,6 @@ def __get_response(session: requests.Session, url: str) -> Any:
 
         result: dict = response.json()
 
-        log.info(f"Response from {url} was:\n    {result}")
-
         return result
     except requests.HTTPError:
         log.error(f"GET Exception to {url} ", exc_info=True)


### PR DESCRIPTION
Teensy fix - the logs were overloaded with URL responses.