### PR TITLE
Invoke pre-processing if file has been downloaded

### DIFF
--- a/data_transfer/tasks/byteflies.py
+++ b/data_transfer/tasks/byteflies.py
@@ -15,7 +15,7 @@ def task_preprocess_data(mongoid: str) -> str:
     Preprocessing tasks on byteflies data.
     """
     record = read_record(mongoid)
-    if not record.is_processed:
+    if record.is_downloaded and not record.is_processed:
         record.is_processed = True
         update_record(record)
     return mongoid

--- a/data_transfer/tasks/dreem.py
+++ b/data_transfer/tasks/dreem.py
@@ -15,7 +15,7 @@ def task_preprocess_data(mongoid: str) -> str:
     Preprocessing tasks on dreem data.
     """
     record = read_record(mongoid)
-    if not record.is_processed:
+    if record.is_downloaded and not record.is_processed:
         record.is_processed = True
         update_record(record)
     return mongoid

--- a/data_transfer/tasks/vttsma.py
+++ b/data_transfer/tasks/vttsma.py
@@ -15,6 +15,7 @@ def task_preprocess_data(mongoid: str) -> str:
     Preprocessing tasks on dreem data.
     """
     record = read_record(mongoid)
-    record.is_processed = True
-    update_record(record)
+    if record.is_downloaded and not record.is_processed:
+        record.is_processed = True
+        update_record(record)
     return mongoid


### PR DESCRIPTION
As noted in #62, I have identified a bug in the pipeline where `is_downloaded` in a record is not set the True, yet all the subsequent stages (pre-processing, prepare, and upload) are invokved. This is because the pre-processing stage does not check if a record `is_downloaded` and so it is to to True as are all subsequent stages.

#64 adds measures in place to raise an error if such an error occurs, whilst this PR addresses the known bug.

### Testing

1. Modify `__group_by_composite_key` in `/db/main.py` by adding an IF statement for the one known user who where this bug was discovered:

```python
if _record.patient_id in ["USER_ID"]:
    key = f"{_record.patient_id}/{_record.device_id}"
    results[key].append(_record)
```
3. Run the DRM pipeline and note that the error no long exists.

Ideally do both steps on master and then on this branch to see the change in action. Note that when on master the patient's records (1/2 dreem files) will be uploaded to DMP whereas when on this branch none will be uploaded and all subsequent stages will be false.