### PR TITLE
Control BTF authentication via env. variables; cache part of BTF API; resolves #60

### DIFF
--- a/data_transfer/devices/byteflies.py
+++ b/data_transfer/devices/byteflies.py
@@ -4,8 +4,6 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional
 
-import requests
-
 from data_transfer import utils
 from data_transfer.config import config
 from data_transfer.db import all_hashes, create_record, read_record, update_record
@@ -55,23 +53,8 @@ class Byteflies:
         Authenticate with AWS cognito to access ByteFlies resources
         """
         self.study_site = study_site
-        self.session = self.authenticate()
         self.device_type = utils.DeviceType.BTF
         self.file_type = ".csv"
-
-    def authenticate(self) -> requests.Session:
-        """
-        Authenticate once when object created to share session between requests
-        """
-        credentials = dict(
-            username=config.byteflies_username,
-            password=config.byteflies_password,
-            client_id=config.byteflies_aws_client_id,
-        )
-        token = byteflies_api.get_token(credentials)
-        session = byteflies_api.get_session(token)
-        log.info("Authentication successful")
-        return session
 
     def download_metadata(self, from_date: int, to_date: int) -> None:
         """
@@ -83,7 +66,6 @@ class Byteflies:
         """
         # Note: includes metadata for ALL data records, therefore we must filter them
         all_records = byteflies_api.get_list(
-            self.session,
             config.byteflies_group_ids[self.study_site],
             from_date,
             to_date,
@@ -197,7 +179,6 @@ class Byteflies:
             return
 
         filename = byteflies_api.download_file(
-            self.session,
             record.download_folder(),
             record.meta["studysite_id"],
             record.meta["recording_id"],

--- a/data_transfer/lib/byteflies.py
+++ b/data_transfer/lib/byteflies.py
@@ -16,7 +16,7 @@ from data_transfer.utils import DeviceType, uid_to_hash
 log = logging.getLogger(__name__)
 
 
-def __btf_access_token(forced: bool = False) -> str:
+def btf_access_token(forced: bool = False) -> str:
     """Obtain (or refresh) an access token. Can be forced (in case of 401 HTTP error)"""
 
     now = int(datetime.utcnow().timestamp())
@@ -52,13 +52,13 @@ def __btf_access_token(forced: bool = False) -> str:
             resp = res.json()
             access_token = str(resp["AuthenticationResult"]["IdToken"])
 
-            os.environ["UCAM_ACCESS_TOKEN"] = access_token
-            os.environ["UCAM_ACCESS_TOKEN_GEN_TIME"] = str(now)
+            os.environ["BTF_ACCESS_TOKEN"] = access_token
+            os.environ["BTF_ACCESS_TOKEN_GEN_TIME"] = str(now)
 
         except Exception:
             log.error("Exception:", exc_info=True)
 
-    return os.getenv("UCAM_ACCESS_TOKEN")
+    return os.getenv("BTF_ACCESS_TOKEN")
 
 
 def get_list(studysite_id: str, from_date: int, to_date: int) -> List[dict]:
@@ -149,7 +149,7 @@ def __get_response(url: str) -> Any:
     #    If ~once per second, should not be a problem
     time.sleep(0.5)
     try:
-        headers = {"Authorization": f"{__btf_access_token()}"}
+        headers = {"Authorization": f"{btf_access_token()}"}
         response = requests.get(url, headers=headers)
         log.info(f"Response from {url} was:\n    {response.headers}")
         response.raise_for_status()

--- a/data_transfer/lib/byteflies.py
+++ b/data_transfer/lib/byteflies.py
@@ -1,7 +1,9 @@
 import json
 import logging
+import os
 import time
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 from typing import Any, List, Optional
 
@@ -13,46 +15,52 @@ from data_transfer.utils import DeviceType, uid_to_hash
 log = logging.getLogger(__name__)
 
 
-def get_token(creds: dict) -> str:
-    """
-    Generates a AWS Cognito IdToken for API access
-    # NOTE: generally expires in 60 minutes
-    # TODO: establish token refreshing depending on \
-        frequency/length of DAG
-    """
-    res = requests.post(
-        f"{config.byteflies_aws_auth_url}",
-        headers={
-            "X-Amz-Target": "AWSCognitoIdentityProviderService.InitiateAuth",
-            "Content-Type": "application/x-amz-json-1.1",
-        },
-        json={
-            "ClientId": f"{creds['client_id']}",
-            "AuthFlow": "USER_PASSWORD_AUTH",
-            "AuthParameters": {
-                "USERNAME": f"{creds['username']}",
-                "PASSWORD": f"{creds['password']}",
-            },
-        },
-    )
-    #  TODO: catch/log exception
-    res.raise_for_status()
-    resp = res.json()
-    return str(resp["AuthenticationResult"]["IdToken"])
+def __btf_access_token(forced: bool = False) -> str:
+    """Obtain (or refresh) an access token. Can be forced (in case of 401 HTTP error)"""
+
+    now = int(datetime.utcnow().timestamp())
+    last_created = int(os.getenv("UCAM_ACCESS_TOKEN_GEN_TIME", 0))
+
+    # Refresh the token every 50 minutes  i.e., below 60 minute limit.
+    token_expired = (last_created + (60 * 50)) <= now
+
+    if token_expired or forced:
+        try:
+            username = config.byteflies_username
+            password = config.byteflies_password
+            client_id = config.byteflies_aws_client_id
+
+            res = requests.post(
+                f"{config.byteflies_aws_auth_url}",
+                headers={
+                    "X-Amz-Target": "AWSCognitoIdentityProviderService.InitiateAuth",
+                    "Content-Type": "application/x-amz-json-1.1",
+                },
+                json={
+                    "ClientId": f"{client_id}",
+                    "AuthFlow": "USER_PASSWORD_AUTH",
+                    "AuthParameters": {
+                        "USERNAME": f"{username}",
+                        "PASSWORD": f"{password}",
+                    },
+                },
+            )
+
+            res.raise_for_status()
+            log.info("Authentication successful")
+            resp = res.json()
+            access_token = str(resp["AuthenticationResult"]["IdToken"])
+
+            os.environ["UCAM_ACCESS_TOKEN"] = access_token
+            os.environ["UCAM_ACCESS_TOKEN_GEN_TIME"] = str(now)
+
+        except Exception:
+            log.error("Exception:", exc_info=True)
+
+    return os.getenv("UCAM_ACCESS_TOKEN")
 
 
-def get_session(token: str) -> requests.Session:
-    """
-    Builds a requests session object with the required header
-    """
-    session = requests.Session()
-    session.headers.update({"Authorization": f"{token}"})
-    return session
-
-
-def get_list(
-    session: requests.Session, studysite_id: str, from_date: int, to_date: int
-) -> List[dict]:
+def get_list(studysite_id: str, from_date: int, to_date: int) -> List[dict]:
     """
     GET a list of records (metadata) across study sites, or 'groups' in ByteFlies API
     """
@@ -77,16 +85,12 @@ def get_list(
 
     results: List[dict] = []
 
-    recordings: dict = __get_recordings_by_group(
-        session, studysite_id, from_date, to_date
-    )
+    recordings: dict = __get_recordings_by_group(studysite_id, from_date, to_date)
 
     # query each recording to retrieve total number of files to download
     # this will be done again in download file to get a temporary download link
     for recording in recordings:
-        recording_details: dict = __get_recording_by_id(
-            session, studysite_id, recording["id"]
-        )
+        recording_details: dict = __get_recording_by_id(studysite_id, recording["id"])
 
         for signal in recording_details["signals"]:
             del signal["rawData"]
@@ -103,7 +107,6 @@ def get_list(
 
 
 def download_file(
-    session: requests.Session,
     download_folder: Path,
     studysite_id: str,
     recording_id: str,
@@ -114,7 +117,7 @@ def download_file(
     Download all files associated with one ByteFlies recording.
     """
     try:
-        details: dict = __get_recording_by_id(session, studysite_id, recording_id)
+        details: dict = __get_recording_by_id(studysite_id, recording_id)
         signal: dict = next(
             (s for s in details["signals"] if s["id"] == signal_id), None
         )
@@ -122,9 +125,7 @@ def download_file(
             (signal["rawData"], signal_id)
             if not algorithm_id
             else (
-                __get_algorithm_uri_by_id(
-                    session, studysite_id, recording_id, algorithm_id
-                ),
+                __get_algorithm_uri_by_id(studysite_id, recording_id, algorithm_id),
                 algorithm_id,
             )
         )
@@ -137,7 +138,7 @@ def download_file(
         return None
 
 
-def __get_response(session: requests.Session, url: str) -> Any:
+def __get_response(url: str) -> Any:
     """
     Wrapper method to execute a GET request. Gives a second
     break to avoid 429 / 502 TooManyRequests (as advised)
@@ -146,7 +147,8 @@ def __get_response(session: requests.Session, url: str) -> Any:
     #    If once per second, should not be a problem
     time.sleep(1)
     try:
-        response = session.get(url)
+        headers = {"Authorization": f"{__btf_access_token()}"}
+        response = requests.get(url, headers=headers)
         log.info(f"Response from {url} was:\n    {response.headers}")
         response.raise_for_status()
 
@@ -158,43 +160,36 @@ def __get_response(session: requests.Session, url: str) -> Any:
         return False
 
 
-def __get_groups(session: requests.Session) -> List[str]:
+def __get_groups() -> List[str]:
     """
     Returns the list of groupIds associated with a User Account.
     NOTE: groupIds are hardcoded, so this method is here for posterity
     """
-    groups = __get_response(session, f"{config.byteflies_api_url}/groups/")
+    groups = __get_response(f"{config.byteflies_api_url}/groups/")
     group_ids = [g["groupId"] for g in groups]
     return group_ids
 
 
-def __get_recordings_by_group(
-    session: requests.Session, studysite_id: str, begin_date: int, end_date: int
-) -> Any:
+def __get_recordings_by_group(studysite_id: str, begin_date: int, end_date: int) -> Any:
     """Returns the list of Recordings associated to a Group"""
     return __get_response(
-        session,
         f"{config.byteflies_api_url}/groups/{studysite_id}"
         f"/recordings?begin={begin_date}&end={end_date}",
     )
 
 
-def __get_recording_by_id(
-    session: requests.Session, studysite_id: str, recording_id: str
-) -> Any:
+def __get_recording_by_id(studysite_id: str, recording_id: str) -> Any:
     """Returns the details of a particular Recording"""
     return __get_response(
-        session,
         f"{config.byteflies_api_url}/groups/{studysite_id}/recordings/{recording_id}/",
     )
 
 
 def __get_algorithm_uri_by_id(
-    session: requests.Session, studysite_id: str, recording_id: str, algorithm_id: str
+    studysite_id: str, recording_id: str, algorithm_id: str
 ) -> str:
     """Returns the details of a particular Recording"""
     payload = __get_response(
-        session,
         f"{config.byteflies_api_url}/groups/{studysite_id}"
         f"/recordings/{recording_id}/algorithms/{algorithm_id}",
     )
@@ -204,7 +199,7 @@ def __get_algorithm_uri_by_id(
 def __download_file(download_folder: Path, url: str, filename: str) -> bool:
     """
     Builds the target filename and starts downloading the file to disk
-    No session parameter as this queries a non-BTF url with authentication
+    Not used the btf_get method as this queries a non-BTF url with authentication
     embedded in the url
     """
     try:

--- a/tests/data_transfer_tests/byteflies/conftest.py
+++ b/tests/data_transfer_tests/byteflies/conftest.py
@@ -71,9 +71,8 @@ def mock_requests_session() -> dict:
 
 
 @pytest.fixture
-@patch.object(byteflies.Byteflies, "authenticate")
 @patch.object(byteflies, "StudySite")
-def populated_db(mock_authenticate: Mock, mock_city: Mock) -> Collection:
+def populated_db(mock_city: Mock) -> Collection:
     # path db with mock
     mock_db = mongomock.MongoClient().db
     # get mock data

--- a/tests/data_transfer_tests/byteflies/test_byteflies.py
+++ b/tests/data_transfer_tests/byteflies/test_byteflies.py
@@ -37,7 +37,7 @@ def test_download_file(mock_requests_session: dict, tmpdir: Path) -> None:
     assert Path(tmpdir / "random_id_13.csv").is_file()
 
 
-def test_recording_by_id(mock_requests_session: dict, tmpdir: Path) -> None:
+def test_recording_by_id() -> None:
     # TODO: involve Byteflies()__get_timestamp()
     lib.__get_recording_by_id.cache_clear()
     response = MagicMock()

--- a/tests/data_transfer_tests/byteflies/test_byteflies.py
+++ b/tests/data_transfer_tests/byteflies/test_byteflies.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 from pymongo.collection import Collection
 
@@ -8,16 +8,16 @@ from data_transfer.db import main as db
 from data_transfer.lib import byteflies as lib
 
 
-@patch.object(lib.time, "sleep")
+@patch.object(lib.time, "sleep", scope="function")
 def test_get_list(mock_time_sleep: Mock, mock_requests_session: dict) -> None:
 
-    result = lib.get_list(mock_requests_session["session"], "studysite_1", 0, 1)
+    with patch.object(lib, "requests", mock_requests_session["session"]):
 
-    # NOTE: Can't replicate, but sleep_call_count failed on me once (was 26853)
-    assert mock_time_sleep.call_count == 5
-    assert mock_requests_session["get_all"].call_count == 1
-    assert mock_requests_session["get_one"].call_count == 4
-    assert len(result) == 40
+        result = lib.get_list("studysite_1", 0, 1)
+
+        assert mock_requests_session["get_all"].call_count == 1
+        assert mock_requests_session["get_one"].call_count == 4
+        assert len(result) == 40
 
 
 def test_download_file(mock_requests_session: dict, tmpdir: Path) -> None:
@@ -28,18 +28,31 @@ def test_download_file(mock_requests_session: dict, tmpdir: Path) -> None:
     ):
 
         result = lib.download_file(
-            mock_requests_session["session"],
-            tmpdir,
-            "studysite_1",
-            "random_id_12",
-            "random_id_13",
-            "",
+            tmpdir, "studysite_1", "random_id_12", "random_id_13", "", 0
         )
 
     assert result
     assert mock_requests_session["get_one"].call_count == 1
     assert mock_requests_session["get_file"].call_count == 1
     assert Path(tmpdir / "random_id_13.csv").is_file()
+
+
+def test_recording_by_id(mock_requests_session: dict, tmpdir: Path) -> None:
+    # TODO: involve Byteflies()__get_timestamp()
+    lib.__get_recording_by_id.cache_clear()
+    response = MagicMock()
+
+    timestamps = [0, 0, 0, 1]
+
+    with patch.object(lib, "__get_response", response):
+        for time in timestamps:
+            lib.__get_recording_by_id("studysite_1", "random_id_12", time)
+
+        result = lib.__get_recording_by_id.cache_info()
+
+        assert result[0] == 2  # two 'hits' on the cache
+        assert result[1] == 2  # two 'misses' on the cache
+        assert response.call_count == 2  # same as the misses
 
 
 def test_populated_db(populated_db: Collection) -> None:


### PR DESCRIPTION
In this PR, I've restructured BTF's authentication from being a class attribute, to being stored in the environmental variables; much like how this is done at the `dmpy` package. This will ensure that the authentication is re-done every 50 minutes (10 minutes before a token expires) - this check is triggered when preparing for an actual GET request. The proposed solution moved the _authentication_ to the `lib/byteflies.py` and thereby also removes the need to pass a `requests.Session` variable around. 

Additionally, I've cached the `__get_recording_by_id()` (maxsize of 1). Since we wanted the code to run for any individual file, at any time (no dependencies on living variables), the pipeline made subsequent calls to the exact same API endpoint. With the proposed changes, the result of this call is cached for max 5 minutes (since the links in the payload are valid for only 10). A quick test shows (for example) out of 21 files to be downloaded from one recording, 7 files to be downloaded were based on the same API call and have now been reduced to one. The other 14 calls could not be cached as they call a deeper API link to retrieve the algorithm download url; which has to be done for each algorithm file. I've turned down the `sleep.time()` from 1 to .5 to speed this up a bit.

## Testing
- `poetry run nox -r`
- set env's to point to local mongoDB
- clear mongo,DB data and upload folder
- `poetry run consumer`
- `python data_transfer/main.py BTF Muenster 0 3`
- (increase the _3_ to keep adding records; i.e. go further back in time)

Any feedback highly appreciated @jawrainey @ColinBD !