### PR TITLE
Use latest DMPy version

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -180,7 +180,7 @@ python-versions = "*"
 
 [[package]]
 name = "dmpy"
-version = "0.1.0"
+version = "0.1.3"
 description = "Python package to access the IDEA-FAST Data Management Portal (DMP)"
 category = "main"
 optional = false
@@ -197,8 +197,8 @@ cli = ["colorama[cli] (>=0.4.4,<0.5.0)", "pandas[cli] (>=1.1.4,<2.0.0)"]
 [package.source]
 type = "git"
 url = "https://github.com/ideafast/dmpy"
-reference = "0.1.2"
-resolved_reference = "b22b04b6c5a0585e78d58522aeb85a82c52b1351"
+reference = "0.1.3"
+resolved_reference = "d13c49030370156c90f42467d381c808304c5641"
 
 [[package]]
 name = "fastapi"

--- a/poetry.lock
+++ b/poetry.lock
@@ -611,20 +611,6 @@ toml = "*"
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
 
 [[package]]
-name = "pytest-mock"
-version = "3.5.1"
-description = "Thin-wrapper around the mock package for easier use with pytest"
-category = "dev"
-optional = false
-python-versions = ">=3.5"
-
-[package.dependencies]
-pytest = ">=5.0"
-
-[package.extras]
-dev = ["pre-commit", "tox", "pytest-asyncio"]
-
-[[package]]
 name = "python-dateutil"
 version = "2.8.1"
 description = "Extensions to the standard Python datetime module"
@@ -845,7 +831,7 @@ testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "af45292312d7046de80a9862be460ea57b631b2ddd479aa288e92e195cb33b4c"
+content-hash = "c970586f8ea6b7860fe0345a74895ae7f488817808978e0e17b26019e09439b8"
 
 [metadata.files]
 appdirs = [
@@ -1155,10 +1141,6 @@ pyparsing = [
 pytest = [
     {file = "pytest-6.2.2-py3-none-any.whl", hash = "sha256:b574b57423e818210672e07ca1fa90aaf194a4f63f3ab909a2c67ebb22913839"},
     {file = "pytest-6.2.2.tar.gz", hash = "sha256:9d1edf9e7d0b84d72ea3dbcdfd22b35fb543a5e8f2a60092dd578936bf63d7f9"},
-]
-pytest-mock = [
-    {file = "pytest-mock-3.5.1.tar.gz", hash = "sha256:a1e2aba6af9560d313c642dae7e00a2a12b022b80301d9d7fc8ec6858e1dd9fc"},
-    {file = "pytest_mock-3.5.1-py3-none-any.whl", hash = "sha256:379b391cfad22422ea2e252bdfc008edd08509029bcde3c25b2c0bd741e0424e"},
 ]
 python-dateutil = [
     {file = "python-dateutil-2.8.1.tar.gz", hash = "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,10 +30,8 @@ nox = "^2020.12.31"
 isort = "^5.7.0"
 mypy = "^0.800"
 pre-commit = "^2.10.0"
-pytest-mock = "^3.5.1"
 requests-mock = "^1.8.0"
 mongomock = "^3.22.1"
-pymongo = "^3.11.3"
 nox-poetry = "^0.8.4"
 
 [tool.poetry.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ python-dotenv = "^0.15.0"
 pymongo = "^3.11.2"
 boto3 = "^1.16.61"
 mypy-boto3-s3 = "^1.17.22"
-dmpy = {git = "https://github.com/ideafast/dmpy", rev = "0.1.2"}
+dmpy = {git = "https://github.com/ideafast/dmpy", rev = "0.1.3"}
 
 [tool.poetry.dev-dependencies]
 click = "^7.1.2"


### PR DESCRIPTION
The DMP returns a list of errors as a response if an error occurs. Therefore, if a file is attempted to be uploaded and an error occurs, then it is marked as uploaded because the prior dmpy logic did not account for this. This was resolved in [dmpy#7](https://github.com/ideafast/dmpy/pull/7) and so this PR adds the latest package with the changes.

### Testing

1. Review changes
2. Run `poetry install` and `poetry run nox` locally 