### PR TITLE
GitHub Action for Tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,29 @@
+name: Unit Tests
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version: [3.8]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install poetry
+          poetry install
+
+      - name: Run Tests
+        env:
+          IS_TESTING: True
+        run: poetry run nox -rs tests

--- a/consumer/config.py
+++ b/consumer/config.py
@@ -3,22 +3,20 @@ from functools import lru_cache
 from dotenv import load_dotenv
 from pydantic import BaseSettings
 
-load_dotenv(".consumer.env")
-
 
 class Settings(BaseSettings):
-    inventory_base_url: str
-    inventory_token: str
+    inventory_base_url: str = ""
+    inventory_token: str = ""
     module_name: str = "consumer.main"
     variable_name: str = "consumer"
-    log_level: str
-    support_base_url: str
-    support_token: str
-    access_authenticated_endpoints: bool
+    log_level: str = ""
+    support_base_url: str = ""
+    support_token: str = ""
 
 
 @lru_cache()
 def settings() -> Settings:
+    load_dotenv(".consumer.env")
     return Settings()
 
 

--- a/consumer/main.py
+++ b/consumer/main.py
@@ -1,7 +1,6 @@
 from fastapi import FastAPI
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
-from .config import config
 from .routers import auth, devices, inventory, support
 from .utils.errors import CustomException, custom_error_handler, http_error_handler
 from .utils.general import CustomResponse
@@ -11,9 +10,8 @@ consumer = FastAPI(default_response_class=CustomResponse)
 consumer.include_router(auth.router)
 consumer.include_router(devices.router)
 
-if config.access_authenticated_endpoints:
-    consumer.include_router(inventory.router, prefix="/inventory")
-    consumer.include_router(support.router, prefix="/support")
+consumer.include_router(inventory.router, prefix="/inventory")
+consumer.include_router(support.router, prefix="/support")
 
 consumer.add_exception_handler(StarletteHTTPException, http_error_handler)
 consumer.add_exception_handler(CustomException, custom_error_handler)

--- a/data_transfer/config.py
+++ b/data_transfer/config.py
@@ -40,17 +40,19 @@ class GlobalConfig(BaseSettings):
 
     ucam_data: Path = csvs_path / "ucam_db.csv"
 
+    database_uri: str = "mongodb://user:password@localhost:27017"
+    database_name: str = "pipeline_local"
+
+    inventory_api: str = ""
+    support_base_url: str = ""
+    support_token: str = ""
+
+    # TODO: as BTF tests invoke lib private methods this is required
+    byteflies_api_url: str = ""
+
 
 class Settings(GlobalConfig):
     is_dev: bool
-
-    # IDEAFAST
-    database_uri: str
-    database_name: str
-
-    inventory_api: str
-    support_base_url: str
-    support_token: str
 
     # DATA MANAGEMENT PORTAL
     dmp_study_id: str
@@ -105,7 +107,7 @@ class Settings(GlobalConfig):
 
 
 @lru_cache()
-def settings() -> Settings:
+def settings() -> GlobalConfig:
     """
     Only a few services provide development environments, e.g., DMPY.
     As such, live APIs are used for most local developement and
@@ -117,6 +119,9 @@ def settings() -> Settings:
     if get_env_value("IS_DEV"):
         # Override specific prod values, e.g., DMP.
         load_dotenv(".dtransfer.dev.env", override=True)
+
+    if get_env_value("IS_TESTING"):
+        return GlobalConfig()
 
     return Settings()
 

--- a/data_transfer/config.py
+++ b/data_transfer/config.py
@@ -47,9 +47,6 @@ class GlobalConfig(BaseSettings):
     support_base_url: str = ""
     support_token: str = ""
 
-    # TODO: as BTF tests invoke lib private methods this is required
-    byteflies_api_url: str = ""
-
 
 class Settings(GlobalConfig):
     is_dev: bool

--- a/tests/data_transfer_tests/byteflies/conftest.py
+++ b/tests/data_transfer_tests/byteflies/conftest.py
@@ -1,7 +1,7 @@
 import re
 from pathlib import Path
-from typing import IO
-from unittest.mock import Mock, patch
+from typing import IO, Generator
+from unittest.mock import MagicMock, Mock, patch
 
 import mongomock
 import pytest
@@ -10,22 +10,31 @@ import requests_mock
 from pymongo.collection import Collection
 
 from data_transfer import utils
-from data_transfer.config import config
 from data_transfer.devices import byteflies
+from data_transfer.lib import byteflies as lib
 from data_transfer.schemas.record import Record
 
 folder = Path(__file__).parent
 
 
+@pytest.fixture(scope="module")
+def mock_config() -> Generator[MagicMock, None, None]:
+
+    nconfig = MagicMock(byteflies_api_url="https://mock_url.com")
+
+    with patch.object(lib, "config", nconfig) as mockconfig:
+        yield mockconfig
+
+
 @pytest.fixture
-def mock_requests_session() -> dict:
+def mock_requests_session(mock_config: Generator[MagicMock, None, None]) -> dict:
     byteflies_response = utils.read_json(Path(f"{folder}/data/byteflies_payload.json"))
+    btf_url = mock_config.byteflies_api_url  # type: ignore[attr-defined]
     session = requests.Session()
     adapter = requests_mock.Adapter()
 
-    config.byteflies_api_url = f"mock://{config.byteflies_api_url[len('https://'):]}"
-    baseurl = f"{config.byteflies_api_url}/groups/studysite_1/recordings"
-
+    btf_url = f"mock://{btf_url[len('https://'):]}"
+    baseurl = f"{btf_url}/groups/studysite_1/recordings"
     # mocks __get_recordings_by_group
     get_all = adapter.register_uri(
         "GET", baseurl, json=byteflies_response, status_code=200

--- a/tests/data_transfer_tests/byteflies/conftest.py
+++ b/tests/data_transfer_tests/byteflies/conftest.py
@@ -20,7 +20,7 @@ folder = Path(__file__).parent
 @pytest.fixture(scope="module")
 def mock_config() -> Generator[MagicMock, None, None]:
 
-    nconfig = MagicMock(byteflies_api_url="https://mock_url.com")
+    nconfig = MagicMock(byteflies_api_url="mock://mock_url.com")
 
     with patch.object(lib, "config", nconfig) as mockconfig:
         yield mockconfig
@@ -29,12 +29,13 @@ def mock_config() -> Generator[MagicMock, None, None]:
 @pytest.fixture
 def mock_requests_session(mock_config: Generator[MagicMock, None, None]) -> dict:
     byteflies_response = utils.read_json(Path(f"{folder}/data/byteflies_payload.json"))
-    btf_url = mock_config.byteflies_api_url  # type: ignore[attr-defined]
+
     session = requests.Session()
     adapter = requests_mock.Adapter()
 
-    btf_url = f"mock://{btf_url[len('https://'):]}"
-    baseurl = f"{btf_url}/groups/studysite_1/recordings"
+    btfurl = mock_config.byteflies_api_url  # type: ignore[attr-defined]
+    baseurl = f"{btfurl}/groups/studysite_1/recordings"
+
     # mocks __get_recordings_by_group
     get_all = adapter.register_uri(
         "GET", baseurl, json=byteflies_response, status_code=200

--- a/tests/data_transfer_tests/byteflies/test_byteflies.py
+++ b/tests/data_transfer_tests/byteflies/test_byteflies.py
@@ -37,7 +37,7 @@ def test_download_file(mock_requests_session: dict, tmpdir: Path) -> None:
     assert Path(tmpdir / "random_id_13.csv").is_file()
 
 
-def test_recording_by_id() -> None:
+def test_recording_by_id(mock_config: MagicMock) -> None:
     # TODO: involve Byteflies()__get_timestamp()
     lib.__get_recording_by_id.cache_clear()
     response = MagicMock()

--- a/tests/data_transfer_tests/byteflies/test_byteflies.py
+++ b/tests/data_transfer_tests/byteflies/test_byteflies.py
@@ -37,7 +37,7 @@ def test_download_file(mock_requests_session: dict, tmpdir: Path) -> None:
     assert Path(tmpdir / "random_id_13.csv").is_file()
 
 
-def test_recording_by_id(mock_config: MagicMock) -> None:
+def test_recording_by_id() -> None:
     # TODO: involve Byteflies()__get_timestamp()
     lib.__get_recording_by_id.cache_clear()
     response = MagicMock()


### PR DESCRIPTION
Automatically run tests via GitHub Actions when pushed to origin, on PR, or manually (if desired). This PR closes #39 and [saves us from having to run tests locally](https://github.com/ideafast/middleware-services/pull/63#pullrequestreview-628778191).

Changes:

- Set default values for consumer so tests can load settings
- Moved loading of dotenv in consumer to when settings are invoked
- Added default values for database on `data_transfer`

**Note:** I had to modify BTF tests because they depend on internals of the library. Imo, this should ideally be refactored in another PR.

### Testing

- Review code changes
- Review the Actions tab and see the workflow