### PR TITLE
only run GH tests on PR

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,5 @@
 name: Unit Tests
-on: [push, pull_request, workflow_dispatch]
+on: [pull_request, workflow_dispatch]
 
 jobs:
   build:


### PR DESCRIPTION
As we have a consistent flow of creating PRs for any changes, we'd discussed to only run Github Action Tests on a PR to reduce the amount of tests; especially since we push our changes regularly and knowing that tests will fail in these intermediate pushes.