### PR TITLE
fix mypy typing error `config.settings`

### DIFF
--- a/data_transfer/config.py
+++ b/data_transfer/config.py
@@ -1,6 +1,7 @@
 import os
 from functools import lru_cache
 from pathlib import Path
+from typing import Any
 
 from dotenv import get_key, load_dotenv
 from pydantic import BaseSettings
@@ -104,7 +105,7 @@ class Settings(GlobalConfig):
 
 
 @lru_cache()
-def settings() -> GlobalConfig:
+def settings() -> Any:
     """
     Only a few services provide development environments, e.g., DMPY.
     As such, live APIs are used for most local developement and


### PR DESCRIPTION
Interestingly, PR #71 introduced a typing error due to `GlobalConfig` (logically) not having all attributes from `Settings`. However, `settings()` could now return either type. After some experimentation with @jawrainey, it was clear that using `Union[Settings, GlobalConfig]` was not working.

Strangely, the `mypy` session in `poetry run nox -r` does not pick up on this error (and therefore neither does the Github Actions Tests), but the `mypy` session in `pre-commit` as well as `mypy data_transfer` does.

As Jay suggested, although not ideal, using `Any` would give us a quick fix. 

