### PR TITLE
Use None when serializing inventory response

### DIFF
--- a/consumer/schemas/inventory.py
+++ b/consumer/schemas/inventory.py
@@ -17,14 +17,19 @@ class Device(BaseModel):
     @classmethod
     def serialize(cls, device: dict) -> Device:
         """Simplifies reuse across inventory API."""
+
+        def name_or_none(item: dict) -> Optional[str]:
+            """Required as sometimes item may be None as it is a dictionary value."""
+            return item.get("name", None) if item else None
+
         return cls(
             id=device["id"],
             serial=device["serial"].replace(" ", ""),
             device_id=device["asset_tag"],
             is_checkout=device["status_label"]["status_meta"] == "deployed",
-            model=device.get("model", {}).get("name"),
-            manufacturer=device.get("manufacturer", {}).get("name"),
-            location=device.get("location", {}).get("name"),
+            model=name_or_none(device["model"]),
+            manufacturer=name_or_none(device["manufacturer"]),
+            location=name_or_none(device["location"]),
         )
 
 

--- a/tests/consumer_tests/routers/test_inventory.py
+++ b/tests/consumer_tests/routers/test_inventory.py
@@ -16,6 +16,18 @@ def test_device_serial_correct_id(serial_response, client, monkeypatch) -> None:
     assert result is True
 
 
+def test_device_serial_no_location(serial_response, client, monkeypatch) -> None:
+    async def mock_get(path: str, params: str = None):
+        serial_response["rows"][0]["location"] = None
+        return serial_response
+
+    monkeypatch.setattr(inventory, "response", mock_get)
+
+    result = client.get("/inventory/device/byserial/VALID_ID").json()["meta"]["success"]
+
+    assert result is True
+
+
 def test_device_serial_incorrect_id(serial_response, client, monkeypatch) -> None:
     async def mock_get(path: str, params: str = None):
         serial_response.update({"total": 0, "rows": []})


### PR DESCRIPTION
Detailed outlined in #85, but in brief we're trying to access attributes of a dictionary that doesn't exist (it's `None`).

## To reproduce error

1. `git checkout master`
2. `poetry run consumer`
2. Visit [http://0.0.0.0:8000/inventory/devices/bytype/8](http://0.0.0.0:8000/inventory/devices/bytype/8) and observe `Internal Server Error`

## Solution

To see the change checkout this branch, run tests (I've added a new test to confirm this bug), and navigate to the above URL. All should be fine. Closes #85 
