### PR TITLE
remove deviations contraint

### DIFF
--- a/data_transfer/services/ucam.py
+++ b/data_transfer/services/ucam.py
@@ -109,12 +109,6 @@ def determine_by_wear_period(
     if devices:
         for device in devices:
             for patient in device.patients:
-
-                # NOTE: ignores any device ID if record contains deviations
-                # TODO: removes this constraint once faulty device_id assignment has been resolved
-                if patient.deviations:
-                    continue
-
                 patient_start = normalise_day(patient.start_wear)
                 # if end_wear is none, use today
                 patient_end = normalise_day(patient.end_wear or datetime.today())

--- a/tests/data_transfer_tests/services/test_ucam.py
+++ b/tests/data_transfer_tests/services/test_ucam.py
@@ -230,6 +230,25 @@ def test_get_patient_by_period_date_not_found(
         assert result is None
 
 
+def test_get_patient_by_period_date_include_deviations(
+    mock_data: dict, mock_payload: dict, mock_ucam_config: MagicMock
+) -> None:
+    mock_payload.update(
+        {"data": [d for d in mock_data["devices"] if d["device_id"] == "NR3-DEVICE"]}
+    )
+    get_response = MagicMock(json=lambda: mock_payload)
+
+    device_id = "NR3-DEVICE"
+    start_wear = format_weartime("2020-07-21T00:00:00", "ucam")
+    end_wear = format_weartime("2020-07-21T00:00:01", "ucam")
+
+    with patch("requests.get", return_value=get_response):
+
+        result = ucam.patient_by_wear_period(device_id, start_wear, end_wear)
+
+        assert result.patient_id == "B-PATIENT"
+
+
 def test_get_device_by_period_date_within(
     mock_data: dict, mock_ucam_config: MagicMock
 ) -> None:

--- a/tests/data_transfer_tests/services/test_ucam.py
+++ b/tests/data_transfer_tests/services/test_ucam.py
@@ -230,28 +230,6 @@ def test_get_patient_by_period_date_not_found(
         assert result is None
 
 
-# NOTE: this is a temporary measure until device_id's are corrected in
-# the UCAM database and confirmed by all study sites
-# See data_transfer/services/ucam/patient_by_wear_period
-def test_get_patient_by_period_date_ignore_deviations(
-    mock_data: dict, mock_payload: dict, mock_ucam_config: MagicMock
-) -> None:
-    mock_payload.update(
-        {"data": [d for d in mock_data["devices"] if d["device_id"] == "NR3-DEVICE"]}
-    )
-    get_response = MagicMock(json=lambda: mock_payload)
-
-    device_id = "NR3-DEVICE"
-    start_wear = format_weartime("2020-07-21T00:00:00", "ucam")
-    end_wear = format_weartime("2020-07-21T00:00:01", "ucam")
-
-    with patch("requests.get", return_value=get_response):
-
-        result = ucam.patient_by_wear_period(device_id, start_wear, end_wear)
-
-        assert result is None
-
-
 def test_get_device_by_period_date_within(
     mock_data: dict, mock_ucam_config: MagicMock
 ) -> None:


### PR DESCRIPTION
Closes #81 

After filtering and assessing all deviations in UCAM, we can go ahead and lift the restriction that currently ignores any UCAM entry with deviations. There are two or three deviations/comments that indicate we need to manually repair in retrospect, but this outweighs the amount currently skipped due to this constraint.