### PR TITLE
[DRM]: check if report exists before proceeding

### DIFF
--- a/data_transfer/devices/dreem.py
+++ b/data_transfer/devices/dreem.py
@@ -72,7 +72,7 @@ class Dreem:
         known, unknown = 0, 0
 
         for hash_id, item in unknown_records.items():
-            if not item.get("report") and not item["h5file"].get("available"):
+            if not item.get("report") and not item.get("h5file").get("available"):
                 log.debug(f"No report for\n   {item}")
                 continue
             # Pulls out the most relevant metadata for this recording

--- a/data_transfer/devices/dreem.py
+++ b/data_transfer/devices/dreem.py
@@ -72,6 +72,9 @@ class Dreem:
         known, unknown = 0, 0
 
         for hash_id, item in unknown_records.items():
+            if not item.get("report") and not item["h5file"].get("available"):
+                log.debug(f"No report for\n   {item}")
+                continue
             # Pulls out the most relevant metadata for this recording
             recording = self.__recording_metadata(item)
 


### PR DESCRIPTION
As outlined in #95, if a dream datafile has not been processed no report exists, and our pipeline depends on knowing certain information. I propose instead to skip those records until they are processed as in this PR.

# Problem

1. (from master) To reproduce the error run DRM pipeline locally with rotterdam. Make sure to comment [download/upload logic](https://github.com/ideafast/middleware-services/blob/master/data_transfer/dags/drm.py#L33-L46).
2. (from this branch): repeat step (1) and no error will occur.

Closes #95