### PR TITLE
fix unknown IDs

### DIFF
--- a/data_transfer/lib/thinkfast.py
+++ b/data_transfer/lib/thinkfast.py
@@ -75,7 +75,7 @@ def id_in_whitelist(input_ID: str) -> Optional[str]:
 
 def get_participant_id(subjectItems: dict) -> Optional[str]:
     # the ID can be placed in any of the list items. Iterate untill found.
-    ideaId = ""
+    ideaId = None
 
     for item in subjectItems:
         ideaId = format_id_patient(item["text"]) or id_in_whitelist(item["text"])


### PR DESCRIPTION
As @ColinBD indicated, the location of the IDEAFAST valid, or alias, ID can be in a different location in the list of data entries. Originally, we checked for the first two entries - though it seemed, strangely only occurring for one study site, that TFA data can contain a third item in the list, which for a set of patients contained their ID's. I've rewritten the snippet that checks for the ID which now iterates to as many as needed until it finds a valid ID or known alias.